### PR TITLE
Add underscore

### DIFF
--- a/.paperist/templates/index.tex
+++ b/.paperist/templates/index.tex
@@ -13,6 +13,7 @@
 \PassOptionsToPackage{hyphens}{url}
 \usepackage[hidelinks]{hyperref}
 \usepackage{pxjahyper}
+\usepackage[strings]{underscore}
 
 % Cites
 \usepackage{cite}


### PR DESCRIPTION
`DOI`にアンダースコア`_`が入ってた時にエラーがあったので
`% Hyperlink / URL`の末尾に`\usepackage[strings]{underscore}`を入れた